### PR TITLE
Automatically create+associate floating IP to new server

### DIFF
--- a/Exosphere.elm
+++ b/Exosphere.elm
@@ -223,7 +223,8 @@ type alias Uuid =
 
 
 type Msg
-    = ChangeViewState ViewState
+    = Tick Time.Time
+    | ChangeViewState ViewState
     | RequestAuth
     | RequestCreateServer CreateServerRequest
     | RequestDeleteServer Server
@@ -249,7 +250,6 @@ type Msg
     | InputCreateServerUserData CreateServerRequest String
     | InputCreateServerSize CreateServerRequest String
     | InputCreateServerKeypairName CreateServerRequest String
-    | Tick Time.Time
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -490,7 +490,7 @@ receiveAuth model responseResult =
                 newModel =
                     { model | authToken = authToken, viewState = Home }
             in
-                ( newModel, requestNetworks newModel )
+                ( newModel, Cmd.none )
 
 
 requestImages : Model -> Cmd Msg
@@ -620,7 +620,12 @@ receiveServerDetail model server result =
             in
                 case floatingIpState of
                     Requestable ->
-                        ( newModel, getFloatingIpRequestPorts newModel newServer )
+                        ( newModel
+                        , Cmd.batch
+                            [ getFloatingIpRequestPorts newModel newServer
+                            , requestNetworks newModel
+                            ]
+                        )
 
                     _ ->
                         ( newModel, Cmd.none )


### PR DESCRIPTION
Issues to fix:
- [x] ~API call to list ports is made Too Soon after instance is created (and it doesn't have ports yet), and is not retried. So, we aren't trying to create the floating IP until after the next server is created. Dumb fix is to wait some amount of time before listing ports, and maybe retrying if port for new server doesn't appear~
- [x] ~API call to create floating IP for an existing server is made twice (after `receivePorts` and `receiveNetworks` each return), and the second call returns a conflict because the port is already assigned a floating IP.~
- ~There is no retry if the 'create floating IP' API call fails for some reason (or if the app is closed before the API returns a response. Dumb fix is a periodic task to list ports and request floating IPs.~ (most of this is now a non-issue)