### PR TITLE
Multi provider resources view

### DIFF
--- a/src/Rest.elm
+++ b/src/Rest.elm
@@ -369,7 +369,7 @@ createProvider model response =
                     { model
                         | selectedProvider = newProvider
                         , otherProviders = otherProviders
-                        , viewState = ListUserServers
+                        , viewState = ListProviderServers
                     }
             in
                 ( newModel, Cmd.none )
@@ -573,7 +573,7 @@ receiveCreateServer model result =
         Ok _ ->
             let
                 newModel =
-                    { model | viewState = ListUserServers }
+                    { model | viewState = ListProviderServers }
             in
                 ( newModel
                 , Cmd.batch

--- a/src/State.elm
+++ b/src/State.elm
@@ -48,7 +48,7 @@ update msg model =
     case msg of
         Tick _ ->
             case model.viewState of
-                ListUserServers ->
+                ListProviderServers ->
                     ( model, Rest.requestServers model.selectedProvider )
 
                 ServerDetail serverUuid ->
@@ -74,7 +74,7 @@ update msg model =
                     ListImages ->
                         ( newModel, Rest.requestImages model.selectedProvider )
 
-                    ListUserServers ->
+                    ListProviderServers ->
                         ( newModel, Rest.requestServers model.selectedProvider )
 
                     ServerDetail serverUuid ->

--- a/src/State.elm
+++ b/src/State.elm
@@ -68,7 +68,7 @@ update msg model =
                     Login ->
                         ( newModel, Cmd.none )
 
-                    Home ->
+                    ProviderHome ->
                         ( newModel, Cmd.none )
 
                     ListImages ->
@@ -224,7 +224,7 @@ update msg model =
 
         ReceiveDeleteServer _ ->
             {- Todo this ignores the result of server deletion API call, we should display errors to user -}
-            update (ChangeViewState Home) model
+            update (ChangeViewState ProviderHome) model
 
         ReceiveNetworks result ->
             Rest.receiveNetworks model result

--- a/src/State.elm
+++ b/src/State.elm
@@ -68,6 +68,10 @@ update msg model =
                     Login ->
                         ( newModel, Cmd.none )
 
+                    ListAllServers ->
+                        {- Todo request servers for all providers, which reqires refactoring requestServers/receiveServers to update servers for any provider in the model, not just SelectedProvider. -}
+                        ( newModel, Cmd.none )
+
                     ProviderHome ->
                         ( newModel, Cmd.none )
 

--- a/src/Types/Types.elm
+++ b/src/Types/Types.elm
@@ -67,7 +67,7 @@ type Msg
 
 type ViewState
     = Login
-    | Home
+    | ProviderHome
     | ListImages
     | ListProviderServers
     | ServerDetail ServerUuid

--- a/src/Types/Types.elm
+++ b/src/Types/Types.elm
@@ -69,7 +69,7 @@ type ViewState
     = Login
     | Home
     | ListImages
-    | ListUserServers
+    | ListProviderServers
     | ServerDetail ServerUuid
     | CreateServer CreateServerRequest
 

--- a/src/Types/Types.elm
+++ b/src/Types/Types.elm
@@ -11,7 +11,20 @@ import Types.HelperTypes as HelperTypes
 type alias Model =
     { messages : List String
     , viewState : ViewState
-    , selectedProvider : Provider
+    , selectedProvider :
+        Provider
+        {-
+           Todo
+           refactor providers into an ADT which can either be:
+               - Nothing (not logged in)
+               - A tuple of Maybe Provider and List Provider
+            ??
+            We need to cover the following circumstances:
+            - Not logged in to any provider
+            - Logged in to one or more providers, no provider selected
+            - Logged in to one or more providers, with a provider selected
+           Then we can avoid initializing a "dummy provider" with the app
+        -}
     , otherProviders : List Provider
     , creds : Creds
     }

--- a/src/Types/Types.elm
+++ b/src/Types/Types.elm
@@ -67,6 +67,7 @@ type Msg
 
 type ViewState
     = Login
+    | ListAllServers
     | ProviderHome
     | ListImages
     | ListProviderServers

--- a/src/View.elm
+++ b/src/View.elm
@@ -14,7 +14,7 @@ view : Model -> Html Msg
 view model =
     div []
         [ viewMessages model
-        , viewProviderPicker model
+        , viewNav model
         , case model.viewState of
             Login ->
                 viewLogin model
@@ -25,33 +25,28 @@ view model =
             ProviderHome ->
                 div []
                     [ p []
-                        [ viewNav model.selectedProvider
-                        , text ("Home page for " ++ model.selectedProvider.name ++ ", todo put things here")
+                        [ text ("Home page for " ++ model.selectedProvider.name ++ ", todo put things here")
                         ]
                     ]
 
             ListImages ->
                 div []
-                    [ viewNav model.selectedProvider
-                    , viewImages model.selectedProvider
+                    [ viewImages model.selectedProvider
                     ]
 
             ListProviderServers ->
                 div []
-                    [ viewNav model.selectedProvider
-                    , viewServers model.selectedProvider
+                    [ viewServers model.selectedProvider
                     ]
 
             ServerDetail serverUuid ->
                 div []
-                    [ viewNav model.selectedProvider
-                    , viewServerDetail model.selectedProvider serverUuid
+                    [ viewServerDetail model.selectedProvider serverUuid
                     ]
 
             CreateServer createServerRequest ->
                 div []
-                    [ viewNav model.selectedProvider
-                    , viewCreateServer model.selectedProvider createServerRequest
+                    [ viewCreateServer model.selectedProvider createServerRequest
                     ]
         ]
 
@@ -65,10 +60,18 @@ viewMessages model =
     div [] (List.map renderMessage model.messages)
 
 
-viewProviderPicker : Model -> Html Msg
-viewProviderPicker model =
+viewNav : Model -> Html Msg
+viewNav model =
     div []
-        [ h2 [] [ text "Providers" ]
+        [ viewOverallNav model
+        , viewProviderSpecificNav model
+        ]
+
+
+viewOverallNav : Model -> Html Msg
+viewOverallNav model =
+    div []
+        [ button [ onClick (ChangeViewState ListAllServers) ] [ text "All My Stuff" ]
         , div []
             [ text model.selectedProvider.name
             , div [] (List.map renderProviderPicker model.otherProviders)
@@ -77,10 +80,10 @@ viewProviderPicker model =
         ]
 
 
-viewNav : Provider -> Html Msg
-viewNav provider =
+viewProviderSpecificNav : Model -> Html Msg
+viewProviderSpecificNav model =
     div []
-        [ h2 [] [ text "Navigation" ]
+        [ h2 [] [ text "Provider-specific Navigation" ]
         , button [ onClick (ChangeViewState ProviderHome) ] [ text "Home" ]
         , button [ onClick (ChangeViewState ListProviderServers) ] [ text "My Servers" ]
         , button [ onClick (ChangeViewState ListImages) ] [ text "Create Server" ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -19,6 +19,9 @@ view model =
             Login ->
                 viewLogin model
 
+            ListAllServers ->
+                div [] [ text "All servers across all logged-in providers would be listed here" ]
+
             ProviderHome ->
                 div []
                     [ p []

--- a/src/View.elm
+++ b/src/View.elm
@@ -33,7 +33,7 @@ view model =
                     , viewImages model.selectedProvider
                     ]
 
-            ListUserServers ->
+            ListProviderServers ->
                 div []
                     [ viewNav model.selectedProvider
                     , viewServers model.selectedProvider
@@ -79,7 +79,7 @@ viewNav provider =
     div []
         [ h2 [] [ text "Navigation" ]
         , button [ onClick (ChangeViewState Home) ] [ text "Home" ]
-        , button [ onClick (ChangeViewState ListUserServers) ] [ text "My Servers" ]
+        , button [ onClick (ChangeViewState ListProviderServers) ] [ text "My Servers" ]
         , button [ onClick (ChangeViewState ListImages) ] [ text "Create Server" ]
         ]
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -20,7 +20,7 @@ view model =
                 viewLogin model
 
             ListAllServers ->
-                div [] [ text "All servers across all logged-in providers would be listed here" ]
+                div [] [ viewAllServers (model.selectedProvider :: model.otherProviders) ]
 
             ProviderHome ->
                 div []
@@ -36,7 +36,7 @@ view model =
 
             ListProviderServers ->
                 div []
-                    [ viewServers model.selectedProvider
+                    [ viewServersWithActions model.selectedProvider
                     ]
 
             ServerDetail serverUuid ->
@@ -206,8 +206,20 @@ viewImages provider =
                 ]
 
 
-viewServers : Provider -> Html Msg
-viewServers provider =
+viewAllServers : List Provider -> Html Msg
+viewAllServers providers =
+    let
+        providerServerTuples provider =
+            List.map (\s -> ( provider, s )) provider.servers
+
+        providersServerTuples =
+            List.concatMap providerServerTuples providers
+    in
+        div [] (List.map (\( p, s ) -> renderServer p s) providersServerTuples)
+
+
+viewServersWithActions : Provider -> Html Msg
+viewServersWithActions provider =
     case List.isEmpty provider.servers of
         True ->
             div [] [ p [] [ text "You don't have any servers yet, go create one!" ] ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -19,7 +19,7 @@ view model =
             Login ->
                 viewLogin model
 
-            Home ->
+            ProviderHome ->
                 div []
                     [ p []
                         [ viewNav model.selectedProvider
@@ -78,7 +78,7 @@ viewNav : Provider -> Html Msg
 viewNav provider =
     div []
         [ h2 [] [ text "Navigation" ]
-        , button [ onClick (ChangeViewState Home) ] [ text "Home" ]
+        , button [ onClick (ChangeViewState ProviderHome) ] [ text "Home" ]
         , button [ onClick (ChangeViewState ListProviderServers) ] [ text "My Servers" ]
         , button [ onClick (ChangeViewState ListImages) ] [ text "Create Server" ]
         ]


### PR DESCRIPTION
Goal:
- high-level view in UI that shows "all my instances across all providers"
- from this view, let user drill down to the provider/server level

Code so far somewhat works but has issues.

To fix:
- [x] Refactor the model so that a provider doesn't need to be selected, and there needn't be any provider in there at all (which also avoids having to initialize the app with a "dummy" provider) `*` (will be fixed by #71)
- [ ] Kick off `requestServers` for all providers in model when navigating to multi-provider resources view
- [ ] Come up with a better name than "multi-provider resources view" or "All my stuff"

`*` model currently enforces a `selectedProvider` and `otherProviders`; various update/REST functions assume that `selectedProvider` is the provider to be operated upon. If we're exposing views that treat all providers equally (i.e. a view across all providers) then we need to allow the possibility of *no* provider being selected. Likewise, if we're giving users buttons (e.g. "delete") in a view, we need to account for the possibility that a user might delete server(s) from any/multiple provider(s), not just one provider that is selected in the model. Fixing this app-wide is a somewhat large code change (e.g. the update functions now need to know which provider operations are being performed for) but better now than later