### PR TITLE
WIP: Refactoring model so that a provider isn't required to be selected

### DIFF
--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -1,4 +1,4 @@
-module Helpers exposing (processError, processOpenRc, providerNameFromUrl, serviceCatalogToEndpoints, getExternalNetwork, checkFloatingIpState, serverLookup, providerLookup, flavorLookup, imageLookup)
+module Helpers exposing (processError, processOpenRc, providerNameFromUrl, serviceCatalogToEndpoints, getExternalNetwork, checkFloatingIpState, serverLookup, providerLookup, flavorLookup, imageLookup, modelUpdateProvider)
 
 import Regex
 import Maybe.Extra
@@ -168,7 +168,7 @@ providerLookup : Model -> ProviderName -> Maybe Provider
 providerLookup model providerName =
     List.filter
         (\p -> p.name == providerName)
-        (model.selectedProvider :: model.otherProviders)
+        (model.providers)
         |> List.head
 
 
@@ -186,3 +186,15 @@ imageLookup provider imageUuid =
         (\i -> i.uuid == imageUuid)
         provider.images
         |> List.head
+
+
+modelUpdateProvider : Model -> Provider -> Model
+modelUpdateProvider model newProvider =
+    let
+        otherProviders =
+            List.filter (\p -> p.name /= newProvider.name) model.providers
+
+        newProviders =
+            newProvider :: otherProviders
+    in
+        { model | providers = newProviders }

--- a/src/Rest.elm
+++ b/src/Rest.elm
@@ -73,72 +73,102 @@ requestAuthToken model =
 
 requestImages : Provider -> Cmd Msg
 requestImages provider =
-    Http.request
-        { method = "GET"
-        , headers = [ Http.header "X-Auth-Token" provider.authToken ]
-        , url = provider.endpoints.glance ++ "/v2/images"
-        , body = Http.emptyBody
-        , expect = Http.expectJson decodeImages
-        , timeout = Nothing
-        , withCredentials = False
-        }
-        |> Http.send (ReceiveImages provider.name)
+    let
+        request =
+            Http.request
+                { method = "GET"
+                , headers = [ Http.header "X-Auth-Token" provider.authToken ]
+                , url = provider.endpoints.glance ++ "/v2/images"
+                , body = Http.emptyBody
+                , expect = Http.expectJson decodeImages
+                , timeout = Nothing
+                , withCredentials = False
+                }
+
+        resultMsg result =
+            ProviderMsg provider.name (ReceiveImages result)
+    in
+        Http.send resultMsg request
 
 
 requestServers : Provider -> Cmd Msg
 requestServers provider =
-    Http.request
-        { method = "GET"
-        , headers = [ Http.header "X-Auth-Token" provider.authToken ]
-        , url = provider.endpoints.nova ++ "/servers"
-        , body = Http.emptyBody
-        , expect = Http.expectJson decodeServers
-        , timeout = Nothing
-        , withCredentials = False
-        }
-        |> Http.send (ReceiveServers provider.name)
+    let
+        request =
+            Http.request
+                { method = "GET"
+                , headers = [ Http.header "X-Auth-Token" provider.authToken ]
+                , url = provider.endpoints.nova ++ "/servers"
+                , body = Http.emptyBody
+                , expect = Http.expectJson decodeServers
+                , timeout = Nothing
+                , withCredentials = False
+                }
+
+        resultMsg result =
+            ProviderMsg provider.name (ReceiveServers result)
+    in
+        Http.send resultMsg request
 
 
 requestServerDetail : Provider -> ServerUuid -> Cmd Msg
 requestServerDetail provider serverUuid =
-    Http.request
-        { method = "GET"
-        , headers = [ Http.header "X-Auth-Token" provider.authToken ]
-        , url = provider.endpoints.nova ++ "/servers/" ++ serverUuid
-        , body = Http.emptyBody
-        , expect = Http.expectJson decodeServerDetails
-        , timeout = Nothing
-        , withCredentials = False
-        }
-        |> Http.send (ReceiveServerDetail provider.name serverUuid)
+    let
+        request =
+            Http.request
+                { method = "GET"
+                , headers = [ Http.header "X-Auth-Token" provider.authToken ]
+                , url = provider.endpoints.nova ++ "/servers/" ++ serverUuid
+                , body = Http.emptyBody
+                , expect = Http.expectJson decodeServerDetails
+                , timeout = Nothing
+                , withCredentials = False
+                }
+
+        resultMsg result =
+            ProviderMsg provider.name (ReceiveServerDetail serverUuid result)
+    in
+        Http.send resultMsg request
 
 
 requestFlavors : Provider -> Cmd Msg
 requestFlavors provider =
-    Http.request
-        { method = "GET"
-        , headers = [ Http.header "X-Auth-Token" provider.authToken ]
-        , url = provider.endpoints.nova ++ "/flavors"
-        , body = Http.emptyBody
-        , expect = Http.expectJson decodeFlavors
-        , timeout = Nothing
-        , withCredentials = False
-        }
-        |> Http.send (ReceiveFlavors provider.name)
+    let
+        request =
+            Http.request
+                { method = "GET"
+                , headers = [ Http.header "X-Auth-Token" provider.authToken ]
+                , url = provider.endpoints.nova ++ "/flavors"
+                , body = Http.emptyBody
+                , expect = Http.expectJson decodeFlavors
+                , timeout = Nothing
+                , withCredentials = False
+                }
+
+        resultMsg result =
+            ProviderMsg provider.name (ReceiveFlavors result)
+    in
+        Http.send resultMsg request
 
 
 requestKeypairs : Provider -> Cmd Msg
 requestKeypairs provider =
-    Http.request
-        { method = "GET"
-        , headers = [ Http.header "X-Auth-Token" provider.authToken ]
-        , url = provider.endpoints.nova ++ "/os-keypairs"
-        , body = Http.emptyBody
-        , expect = Http.expectJson decodeKeypairs
-        , timeout = Nothing
-        , withCredentials = False
-        }
-        |> Http.send (ReceiveKeypairs provider.name)
+    let
+        request =
+            Http.request
+                { method = "GET"
+                , headers = [ Http.header "X-Auth-Token" provider.authToken ]
+                , url = provider.endpoints.nova ++ "/os-keypairs"
+                , body = Http.emptyBody
+                , expect = Http.expectJson decodeKeypairs
+                , timeout = Nothing
+                , withCredentials = False
+                }
+
+        resultMsg result =
+            ProviderMsg provider.name (ReceiveKeypairs result)
+    in
+        Http.send resultMsg request
 
 
 requestCreateServer : Provider -> CreateServerRequest -> Cmd Msg
@@ -178,6 +208,9 @@ requestCreateServer provider createServerRequest =
                               )
                             ]
                     )
+
+        resultMsg result =
+            ProviderMsg provider.name (ReceiveCreateServer result)
     in
         Cmd.batch
             (requestBodies
@@ -196,7 +229,7 @@ requestCreateServer provider createServerRequest =
                             , timeout = Nothing
                             , withCredentials = True
                             }
-                            |> Http.send (ReceiveCreateServer provider.name)
+                            |> Http.send resultMsg
                         )
                     )
             )
@@ -204,16 +237,22 @@ requestCreateServer provider createServerRequest =
 
 requestDeleteServer : Provider -> Server -> Cmd Msg
 requestDeleteServer provider server =
-    Http.request
-        { method = "DELETE"
-        , headers = [ Http.header "X-Auth-Token" provider.authToken ]
-        , url = provider.endpoints.nova ++ "/servers/" ++ server.uuid
-        , body = Http.emptyBody
-        , expect = Http.expectString
-        , timeout = Nothing
-        , withCredentials = False
-        }
-        |> Http.send (ReceiveDeleteServer provider.name)
+    let
+        request =
+            Http.request
+                { method = "DELETE"
+                , headers = [ Http.header "X-Auth-Token" provider.authToken ]
+                , url = provider.endpoints.nova ++ "/servers/" ++ server.uuid
+                , body = Http.emptyBody
+                , expect = Http.expectString
+                , timeout = Nothing
+                , withCredentials = False
+                }
+
+        resultMsg result =
+            ProviderMsg provider.name (ReceiveDeleteServer result)
+    in
+        Http.send resultMsg request
 
 
 requestDeleteServers : Provider -> List Server -> Cmd Msg
@@ -227,30 +266,42 @@ requestDeleteServers provider serversToDelete =
 
 requestNetworks : Provider -> Cmd Msg
 requestNetworks provider =
-    Http.request
-        { method = "GET"
-        , headers = [ Http.header "X-Auth-Token" provider.authToken ]
-        , url = provider.endpoints.neutron ++ "/v2.0/networks"
-        , body = Http.emptyBody
-        , expect = Http.expectJson decodeNetworks
-        , timeout = Nothing
-        , withCredentials = False
-        }
-        |> Http.send (ReceiveNetworks provider.name)
+    let
+        request =
+            Http.request
+                { method = "GET"
+                , headers = [ Http.header "X-Auth-Token" provider.authToken ]
+                , url = provider.endpoints.neutron ++ "/v2.0/networks"
+                , body = Http.emptyBody
+                , expect = Http.expectJson decodeNetworks
+                , timeout = Nothing
+                , withCredentials = False
+                }
+
+        resultMsg result =
+            ProviderMsg provider.name (ReceiveNetworks result)
+    in
+        Http.send resultMsg request
 
 
 getFloatingIpRequestPorts : Provider -> Server -> Cmd Msg
 getFloatingIpRequestPorts provider server =
-    Http.request
-        { method = "GET"
-        , headers = [ Http.header "X-Auth-Token" provider.authToken ]
-        , url = provider.endpoints.neutron ++ "/v2.0/ports"
-        , body = Http.emptyBody
-        , expect = Http.expectJson decodePorts
-        , timeout = Nothing
-        , withCredentials = False
-        }
-        |> Http.send (GetFloatingIpReceivePorts provider.name server.uuid)
+    let
+        request =
+            Http.request
+                { method = "GET"
+                , headers = [ Http.header "X-Auth-Token" provider.authToken ]
+                , url = provider.endpoints.neutron ++ "/v2.0/ports"
+                , body = Http.emptyBody
+                , expect = Http.expectJson decodePorts
+                , timeout = Nothing
+                , withCredentials = False
+                }
+
+        resultMsg result =
+            ProviderMsg provider.name (GetFloatingIpReceivePorts server.uuid result)
+    in
+        Http.send resultMsg request
 
 
 requestFloatingIpIfRequestable : Model -> Provider -> Network -> Port -> ServerUuid -> ( Model, Cmd Msg )
@@ -301,7 +352,7 @@ requestFloatingIp model provider network port_ server =
                   )
                 ]
 
-        cmd =
+        request =
             Http.request
                 { method = "POST"
                 , headers = [ Http.header "X-Auth-Token" provider.authToken ]
@@ -311,7 +362,12 @@ requestFloatingIp model provider network port_ server =
                 , timeout = Nothing
                 , withCredentials = True
                 }
-                |> Http.send (ReceiveFloatingIp provider.name server.uuid)
+
+        resultMsg result =
+            ProviderMsg provider.name (ReceiveFloatingIp server.uuid result)
+
+        cmd =
+            Http.send resultMsg request
     in
         ( newModel, cmd )
 
@@ -362,7 +418,7 @@ createProvider model response =
                 newModel =
                     { model
                         | providers = newProviders
-                        , viewState = ListProviderServers newProvider.name
+                        , viewState = ProviderView newProvider.name ListProviderServers
                     }
             in
                 ( newModel, Cmd.none )
@@ -563,7 +619,7 @@ receiveCreateServer model provider result =
         Ok _ ->
             let
                 newModel =
-                    { model | viewState = ListProviderServers provider.name }
+                    { model | viewState = ProviderView provider.name ListProviderServers }
             in
                 ( newModel
                 , Cmd.batch

--- a/src/State.elm
+++ b/src/State.elm
@@ -12,7 +12,7 @@ import Rest
 init : ( Model, Cmd Msg )
 init =
     ( { messages = []
-      , viewState = Login
+      , viewState = NonProviderView Login
       , providers = []
       , creds =
             Creds
@@ -37,254 +37,40 @@ update msg model =
     case msg of
         Tick _ ->
             case model.viewState of
-                ListProviderServers providerName ->
-                    case Helpers.providerLookup model providerName of
-                        Nothing ->
-                            Helpers.processError model "Provider not found"
+                NonProviderView _ ->
+                    ( model, Cmd.none )
 
-                        Just provider ->
-                            ( model, Rest.requestServers provider )
+                ProviderView providerName ListProviderServers ->
+                    update (ProviderMsg providerName RequestServers) model
 
-                ServerDetail providerName serverUuid ->
-                    case Helpers.providerLookup model providerName of
-                        Nothing ->
-                            Helpers.processError model "Provider not found"
-
-                        Just provider ->
-                            ( model
-                            , Rest.requestServerDetail provider serverUuid
-                            )
+                ProviderView providerName (ServerDetail serverUuid) ->
+                    update (ProviderMsg providerName (RequestServerDetail serverUuid)) model
 
                 _ ->
                     ( model, Cmd.none )
 
-        ChangeViewState state ->
+        SetNonProviderView nonProviderViewConstructor ->
             let
                 newModel =
-                    { model | viewState = state }
+                    { model | viewState = NonProviderView nonProviderViewConstructor }
             in
-                case state of
+                case nonProviderViewConstructor of
                     Login ->
                         ( newModel, Cmd.none )
-
-                    ProviderHome providerName ->
-                        ( newModel, Cmd.none )
-
-                    ListImages providerName ->
-                        case Helpers.providerLookup model providerName of
-                            Just provider ->
-                                ( newModel, Rest.requestImages provider )
-
-                            Nothing ->
-                                Helpers.processError model "Provider not found"
-
-                    ListProviderServers providerName ->
-                        case Helpers.providerLookup model providerName of
-                            Just provider ->
-                                ( newModel, Rest.requestServers provider )
-
-                            Nothing ->
-                                Helpers.processError model "Provider not found"
-
-                    ServerDetail providerName serverUuid ->
-                        case Helpers.providerLookup model providerName of
-                            Just provider ->
-                                ( newModel
-                                , Cmd.batch
-                                    [ Rest.requestServerDetail provider serverUuid
-                                    , Rest.requestFlavors provider
-                                    , Rest.requestImages provider
-                                    ]
-                                )
-
-                            Nothing ->
-                                Helpers.processError model "Provider not found"
-
-                    CreateServer providerName _ ->
-                        case Helpers.providerLookup newModel providerName of
-                            Just provider ->
-                                ( newModel
-                                , Cmd.batch
-                                    [ Rest.requestFlavors provider
-                                    , Rest.requestKeypairs provider
-                                    ]
-                                )
-
-                            Nothing ->
-                                Helpers.processError model "Provider not found"
 
         RequestNewProviderToken ->
             ( model, Rest.requestAuthToken model )
 
-        RequestCreateServer providerName createServerRequest ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    ( model
-                    , Rest.requestCreateServer provider createServerRequest
-                    )
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        RequestDeleteServer providerName server ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    let
-                        newProvider =
-                            { provider
-                                | servers =
-                                    List.filter
-                                        (\s -> s /= server)
-                                        provider.servers
-                            }
-
-                        newModel =
-                            Helpers.modelUpdateProvider model newProvider
-                    in
-                        ( newModel, Rest.requestDeleteServer newProvider server )
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
         ReceiveAuthToken response ->
             Rest.receiveAuthToken model response
 
-        ReceiveImages providerName result ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    Rest.receiveImages model provider result
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        RequestDeleteServers providerName serversToDelete ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    let
-                        newProvider =
-                            { provider | servers = List.filter (\s -> (not (List.member s serversToDelete))) provider.servers }
-
-                        newModel =
-                            Helpers.modelUpdateProvider model newProvider
-                    in
-                        ( newModel
-                        , Rest.requestDeleteServers newProvider serversToDelete
-                        )
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        SelectServer providerName server newSelectionState ->
+        ProviderMsg providerName msg ->
             case Helpers.providerLookup model providerName of
                 Nothing ->
                     Helpers.processError model "Provider not found"
 
                 Just provider ->
-                    let
-                        updateServer someServer =
-                            if someServer.uuid == server.uuid then
-                                { someServer | selected = newSelectionState }
-                            else
-                                someServer
-
-                        newProvider =
-                            { provider
-                                | servers =
-                                    List.map updateServer provider.servers
-                            }
-
-                        newModel =
-                            Helpers.modelUpdateProvider model newProvider
-                    in
-                        newModel
-                            ! []
-
-        SelectAllServers providerName allServersSelected ->
-            case Helpers.providerLookup model providerName of
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-                Just provider ->
-                    let
-                        updateServer someServer =
-                            { someServer | selected = allServersSelected }
-
-                        newProvider =
-                            { provider | servers = List.map updateServer provider.servers }
-
-                        newModel =
-                            Helpers.modelUpdateProvider model newProvider
-                    in
-                        newModel
-                            ! []
-
-        ReceiveServers providerName result ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    Rest.receiveServers model provider result
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        ReceiveServerDetail providerName serverUuid result ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    Rest.receiveServerDetail model provider serverUuid result
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        ReceiveFlavors providerName result ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    Rest.receiveFlavors model provider result
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        ReceiveKeypairs providerName result ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    Rest.receiveKeypairs model provider result
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        ReceiveCreateServer providerName result ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    Rest.receiveCreateServer model provider result
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        ReceiveDeleteServer providerName _ ->
-            {- Todo this ignores the result of server deletion API call, we should display errors to user -}
-            update (ChangeViewState (ProviderHome providerName)) model
-
-        ReceiveNetworks providerName result ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    Rest.receiveNetworks model provider result
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        GetFloatingIpReceivePorts providerName serverUuid result ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    Rest.receivePortsAndRequestFloatingIp model provider serverUuid result
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
-
-        ReceiveFloatingIp providerName serverUuid result ->
-            case Helpers.providerLookup model providerName of
-                Just provider ->
-                    Rest.receiveFloatingIp model provider serverUuid result
-
-                Nothing ->
-                    Helpers.processError model "Provider not found"
+                    processProviderSpecificMsg model provider msg
 
         {- Form inputs -}
         InputAuthURL authURL ->
@@ -335,34 +121,171 @@ update msg model =
         InputCreateServerName createServerRequest name ->
             let
                 viewState =
-                    CreateServer createServerRequest.providerName { createServerRequest | name = name }
+                    ProviderView createServerRequest.providerName (CreateServer { createServerRequest | name = name })
             in
                 ( { model | viewState = viewState }, Cmd.none )
 
         InputCreateServerCount createServerRequest count ->
             let
                 viewState =
-                    CreateServer createServerRequest.providerName { createServerRequest | count = count }
+                    ProviderView createServerRequest.providerName (CreateServer { createServerRequest | count = count })
             in
                 ( { model | viewState = viewState }, Cmd.none )
 
         InputCreateServerUserData createServerRequest userData ->
             let
                 viewState =
-                    CreateServer createServerRequest.providerName { createServerRequest | userData = userData }
+                    ProviderView createServerRequest.providerName (CreateServer { createServerRequest | userData = userData })
             in
                 ( { model | viewState = viewState }, Cmd.none )
 
         InputCreateServerSize createServerRequest flavorUuid ->
             let
                 viewState =
-                    CreateServer createServerRequest.providerName { createServerRequest | flavorUuid = flavorUuid }
+                    ProviderView createServerRequest.providerName (CreateServer { createServerRequest | flavorUuid = flavorUuid })
             in
                 ( { model | viewState = viewState }, Cmd.none )
 
         InputCreateServerKeypairName createServerRequest keypairName ->
             let
                 viewState =
-                    CreateServer createServerRequest.providerName { createServerRequest | keypairName = keypairName }
+                    ProviderView createServerRequest.providerName (CreateServer { createServerRequest | keypairName = keypairName })
             in
                 ( { model | viewState = viewState }, Cmd.none )
+
+
+processProviderSpecificMsg : Model -> Provider -> ProviderSpecificMsgConstructor -> ( Model, Cmd Msg )
+processProviderSpecificMsg model provider msg =
+    case msg of
+        SetProviderView providerViewConstructor ->
+            let
+                newModel =
+                    { model | viewState = (ProviderView provider.name providerViewConstructor) }
+            in
+                case providerViewConstructor of
+                    ProviderHome ->
+                        ( newModel, Cmd.none )
+
+                    ListImages ->
+                        ( newModel, Rest.requestImages provider )
+
+                    ListProviderServers ->
+                        ( newModel, Rest.requestServers provider )
+
+                    ServerDetail serverUuid ->
+                        ( newModel
+                        , Cmd.batch
+                            [ Rest.requestServerDetail provider serverUuid
+                            , Rest.requestFlavors provider
+                            , Rest.requestImages provider
+                            ]
+                        )
+
+                    CreateServer createServerRequest ->
+                        ( newModel
+                        , Cmd.batch
+                            [ Rest.requestFlavors provider
+                            , Rest.requestKeypairs provider
+                            ]
+                        )
+
+        RequestServers ->
+            ( model, Rest.requestServers provider )
+
+        RequestServerDetail serverUuid ->
+            ( model, Rest.requestServerDetail provider serverUuid )
+
+        RequestCreateServer createServerRequest ->
+            ( model, Rest.requestCreateServer provider createServerRequest )
+
+        RequestDeleteServer server ->
+            let
+                newProvider =
+                    { provider
+                        | servers =
+                            List.filter
+                                (\s -> s /= server)
+                                provider.servers
+                    }
+
+                newModel =
+                    Helpers.modelUpdateProvider model newProvider
+            in
+                ( newModel, Rest.requestDeleteServer newProvider server )
+
+        ReceiveImages result ->
+            Rest.receiveImages model provider result
+
+        RequestDeleteServers serversToDelete ->
+            let
+                newProvider =
+                    { provider | servers = List.filter (\s -> (not (List.member s serversToDelete))) provider.servers }
+
+                newModel =
+                    Helpers.modelUpdateProvider model newProvider
+            in
+                ( newModel
+                , Rest.requestDeleteServers newProvider serversToDelete
+                )
+
+        SelectServer server newSelectionState ->
+            let
+                updateServer someServer =
+                    if someServer.uuid == server.uuid then
+                        { someServer | selected = newSelectionState }
+                    else
+                        someServer
+
+                newProvider =
+                    { provider
+                        | servers =
+                            List.map updateServer provider.servers
+                    }
+
+                newModel =
+                    Helpers.modelUpdateProvider model newProvider
+            in
+                newModel
+                    ! []
+
+        SelectAllServers allServersSelected ->
+            let
+                updateServer someServer =
+                    { someServer | selected = allServersSelected }
+
+                newProvider =
+                    { provider | servers = List.map updateServer provider.servers }
+
+                newModel =
+                    Helpers.modelUpdateProvider model newProvider
+            in
+                newModel
+                    ! []
+
+        ReceiveServers result ->
+            Rest.receiveServers model provider result
+
+        ReceiveServerDetail serverUuid result ->
+            Rest.receiveServerDetail model provider serverUuid result
+
+        ReceiveFlavors result ->
+            Rest.receiveFlavors model provider result
+
+        ReceiveKeypairs result ->
+            Rest.receiveKeypairs model provider result
+
+        ReceiveCreateServer result ->
+            Rest.receiveCreateServer model provider result
+
+        ReceiveDeleteServer _ ->
+            {- Todo this ignores the result of server deletion API call, we should display errors to user -}
+            update (ProviderMsg provider.name (SetProviderView ProviderHome)) model
+
+        ReceiveNetworks result ->
+            Rest.receiveNetworks model provider result
+
+        GetFloatingIpReceivePorts serverUuid result ->
+            Rest.receivePortsAndRequestFloatingIp model provider serverUuid result
+
+        ReceiveFloatingIp serverUuid result ->
+            Rest.receiveFloatingIp model provider serverUuid result

--- a/src/Types/Types.elm
+++ b/src/Types/Types.elm
@@ -11,8 +11,7 @@ import Types.HelperTypes as HelperTypes
 type alias Model =
     { messages : List String
     , viewState : ViewState
-    , selectedProvider : Provider
-    , otherProviders : List Provider
+    , providers : List Provider
     , creds : Creds
     }
 
@@ -34,23 +33,22 @@ type Msg
     = Tick Time.Time
     | ChangeViewState ViewState
     | RequestNewProviderToken
-    | SelectProvider ProviderName
-    | SelectServer Server Bool
-    | SelectAllServers Bool
-    | RequestCreateServer CreateServerRequest
-    | RequestDeleteServer Server
-    | RequestDeleteServers (List Server)
+    | SelectServer ProviderName Server Bool
+    | SelectAllServers ProviderName Bool
+    | RequestCreateServer ProviderName CreateServerRequest
+    | RequestDeleteServer ProviderName Server
+    | RequestDeleteServers ProviderName (List Server)
     | ReceiveAuthToken (Result Http.Error (Http.Response String))
-    | ReceiveImages (Result Http.Error (List Image))
-    | ReceiveServers (Result Http.Error (List Server))
-    | ReceiveServerDetail ServerUuid (Result Http.Error ServerDetails)
-    | ReceiveCreateServer (Result Http.Error Server)
-    | ReceiveDeleteServer (Result Http.Error String)
-    | ReceiveFlavors (Result Http.Error (List Flavor))
-    | ReceiveKeypairs (Result Http.Error (List Keypair))
-    | ReceiveNetworks (Result Http.Error (List Network))
-    | GetFloatingIpReceivePorts ServerUuid (Result Http.Error (List Port))
-    | ReceiveFloatingIp ServerUuid (Result Http.Error IpAddress)
+    | ReceiveImages ProviderName (Result Http.Error (List Image))
+    | ReceiveServers ProviderName (Result Http.Error (List Server))
+    | ReceiveServerDetail ProviderName ServerUuid (Result Http.Error ServerDetails)
+    | ReceiveCreateServer ProviderName (Result Http.Error Server)
+    | ReceiveDeleteServer ProviderName (Result Http.Error String)
+    | ReceiveFlavors ProviderName (Result Http.Error (List Flavor))
+    | ReceiveKeypairs ProviderName (Result Http.Error (List Keypair))
+    | ReceiveNetworks ProviderName (Result Http.Error (List Network))
+    | GetFloatingIpReceivePorts ProviderName ServerUuid (Result Http.Error (List Port))
+    | ReceiveFloatingIp ProviderName ServerUuid (Result Http.Error IpAddress)
     | InputAuthURL String
     | InputProjectDomain String
     | InputProjectName String
@@ -67,11 +65,11 @@ type Msg
 
 type ViewState
     = Login
-    | Home
-    | ListImages
-    | ListUserServers
-    | ServerDetail ServerUuid
-    | CreateServer CreateServerRequest
+    | ProviderHome ProviderName
+    | ListImages ProviderName
+    | ListProviderServers ProviderName
+    | ServerDetail ProviderName ServerUuid
+    | CreateServer ProviderName CreateServerRequest
 
 
 type alias Creds =

--- a/src/Types/Types.elm
+++ b/src/Types/Types.elm
@@ -31,24 +31,10 @@ type alias Provider =
 
 type Msg
     = Tick Time.Time
-    | ChangeViewState ViewState
+    | SetNonProviderView NonProviderViewConstructor
     | RequestNewProviderToken
-    | SelectServer ProviderName Server Bool
-    | SelectAllServers ProviderName Bool
-    | RequestCreateServer ProviderName CreateServerRequest
-    | RequestDeleteServer ProviderName Server
-    | RequestDeleteServers ProviderName (List Server)
     | ReceiveAuthToken (Result Http.Error (Http.Response String))
-    | ReceiveImages ProviderName (Result Http.Error (List Image))
-    | ReceiveServers ProviderName (Result Http.Error (List Server))
-    | ReceiveServerDetail ProviderName ServerUuid (Result Http.Error ServerDetails)
-    | ReceiveCreateServer ProviderName (Result Http.Error Server)
-    | ReceiveDeleteServer ProviderName (Result Http.Error String)
-    | ReceiveFlavors ProviderName (Result Http.Error (List Flavor))
-    | ReceiveKeypairs ProviderName (Result Http.Error (List Keypair))
-    | ReceiveNetworks ProviderName (Result Http.Error (List Network))
-    | GetFloatingIpReceivePorts ProviderName ServerUuid (Result Http.Error (List Port))
-    | ReceiveFloatingIp ProviderName ServerUuid (Result Http.Error IpAddress)
+    | ProviderMsg ProviderName ProviderSpecificMsgConstructor
     | InputAuthURL String
     | InputProjectDomain String
     | InputProjectName String
@@ -63,13 +49,42 @@ type Msg
     | InputCreateServerKeypairName CreateServerRequest String
 
 
+type ProviderSpecificMsgConstructor
+    = SetProviderView ProviderViewConstructor
+    | SelectServer Server Bool
+    | SelectAllServers Bool
+    | RequestServers
+    | RequestServerDetail ServerUuid
+    | RequestCreateServer CreateServerRequest
+    | RequestDeleteServer Server
+    | RequestDeleteServers (List Server)
+    | ReceiveImages (Result Http.Error (List Image))
+    | ReceiveServers (Result Http.Error (List Server))
+    | ReceiveServerDetail ServerUuid (Result Http.Error ServerDetails)
+    | ReceiveCreateServer (Result Http.Error Server)
+    | ReceiveDeleteServer (Result Http.Error String)
+    | ReceiveFlavors (Result Http.Error (List Flavor))
+    | ReceiveKeypairs (Result Http.Error (List Keypair))
+    | ReceiveNetworks (Result Http.Error (List Network))
+    | GetFloatingIpReceivePorts ServerUuid (Result Http.Error (List Port))
+    | ReceiveFloatingIp ServerUuid (Result Http.Error IpAddress)
+
+
 type ViewState
+    = NonProviderView NonProviderViewConstructor
+    | ProviderView ProviderName ProviderViewConstructor
+
+
+type NonProviderViewConstructor
     = Login
-    | ProviderHome ProviderName
-    | ListImages ProviderName
-    | ListProviderServers ProviderName
-    | ServerDetail ProviderName ServerUuid
-    | CreateServer ProviderName CreateServerRequest
+
+
+type ProviderViewConstructor
+    = ProviderHome
+    | ListImages
+    | ListProviderServers
+    | ServerDetail ServerUuid
+    | CreateServer CreateServerRequest
 
 
 type alias Creds =

--- a/src/View.elm
+++ b/src/View.elm
@@ -78,11 +78,10 @@ viewMessages model =
 
 viewProviderPicker : Model -> Html Msg
 viewProviderPicker model =
-    {- Todo make "selected provider" a pattern-match-accessible part ov viewState -}
     div []
         [ h2 [] [ text "Providers" ]
         , div []
-            [ div [] (List.map renderProviderPicker model.providers)
+            [ div [] (List.map (renderProviderPicker model) model.providers)
             ]
         , button [ onClick (SetNonProviderView Login) ] [ text "Add Provider" ]
         ]
@@ -429,14 +428,23 @@ renderMessage message =
     p [] [ text message ]
 
 
-renderProviderPicker : Provider -> Html Msg
-renderProviderPicker provider =
-    case provider.name of
-        "" ->
-            div [] []
+renderProviderPicker : Model -> Provider -> Html Msg
+renderProviderPicker model provider =
+    let
+        isSelected p =
+            case model.viewState of
+                NonProviderView _ ->
+                    False
 
-        _ ->
-            button [ onClick (ProviderMsg provider.name (SetProviderView ProviderHome)) ] [ text provider.name ]
+                ProviderView selectedProvName _ ->
+                    p.name == selectedProvName
+    in
+        case isSelected provider of
+            False ->
+                button [ onClick (ProviderMsg provider.name (SetProviderView ProviderHome)) ] [ text provider.name ]
+
+            True ->
+                text provider.name
 
 
 renderImage : Provider -> Image -> Html Msg


### PR DESCRIPTION
This work fixes #70 and mostly undoes #55. It is required to support views of resources across all providers.

Problems to fix:
- [x] Case statements everywhere. `ViewState` ADT should have a `SelectedProviderName` broken out from inside the type constructor (??) which is resolved to a `Provider` type **once** in the code, before passing to view and update functions
- [x] "Provider picker" view does not highlight/disable button for selected provider, this is a regression