### PR TITLE
Problem: double quotes around $OS_* values included on openrc import

### DIFF
--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -20,12 +20,12 @@ processOpenRc : Model -> String -> Creds
 processOpenRc model openRc =
     let
         regexes =
-            { authUrl = Regex.regex "export OS_AUTH_URL=(.*)"
-            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=(.*)"
-            , projectName = Regex.regex "export OS_PROJECT_NAME=(.*)"
-            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=(.*)"
-            , username = Regex.regex "export OS_USERNAME=(.*)"
-            , password = Regex.regex "export OS_PASSWORD=(.*)"
+            { authUrl = Regex.regex "export OS_AUTH_URL=\"(.*)\""
+            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=\"(.*)\""
+            , projectName = Regex.regex "export OS_PROJECT_NAME=\"(.*)\""
+            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"(.*)\""
+            , username = Regex.regex "export OS_USERNAME=\"(.*)\""
+            , password = Regex.regex "export OS_PASSWORD=\"(.*)\""
             }
 
         getMatch text regex =


### PR DESCRIPTION
This fixes Issue #67.

Summary: Exclude environment variables double quotes when importing `openrc`

Previously, the `Regex.regex` was doing a match/capture on everything following the `=`, so the match includes `"around/value"`. This alters the regex to only match what is contained within "double quotes".

Screenshots or screen interaction captured provided upon request.