### PR TITLE
Problem: after openrc import, a user might not know to enter password

### DIFF
--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -1,4 +1,4 @@
-module Helpers exposing (processError, processOpenRc, providerNameFromUrl, serviceCatalogToEndpoints, getExternalNetwork, checkFloatingIpState, serverLookup, providerLookup, flavorLookup, imageLookup, modelUpdateProvider)
+module Helpers exposing (processError, processOpenRc, providePasswordHint, providerNameFromUrl, serviceCatalogToEndpoints, getExternalNetwork, checkFloatingIpState, serverLookup, providerLookup, flavorLookup, imageLookup, modelUpdateProvider)
 
 import Regex
 import Maybe.Extra
@@ -46,6 +46,23 @@ processOpenRc model openRc =
             (newField regexes.userDomain model.creds.userDomain)
             (newField regexes.username model.creds.username)
             (newField regexes.password model.creds.password)
+
+
+providePasswordHint : String -> String -> List ( String, String )
+providePasswordHint username password =
+    let
+        checks =
+            [ (not <| String.isEmpty username)
+            , (String.isEmpty password)
+            , (username /= "demo")
+            ]
+    in
+        if List.all (\p -> p) checks then
+            [ ( "border-color", "rgba(239, 130, 17, 0.8)" )
+            , ( "background-color", "rgba(245, 234, 234, 0.7)" )
+            ]
+        else
+            []
 
 
 providerNameFromUrl : HelperTypes.Url -> ProviderName

--- a/src/View.elm
+++ b/src/View.elm
@@ -168,6 +168,7 @@ viewLogin model =
                 , td []
                     [ input
                         [ type_ "password"
+                        , Attr.style (Helpers.providePasswordHint model.creds.username model.creds.password)
                         , value model.creds.password
                         , onInput (\p -> InputLoginField (Password p))
                         ]


### PR DESCRIPTION
This address the lack of "hint" to enter a password following an `openrc` import. 

This resolves #68 (following #85 - where the Bash variable no longer was matched). 

A sample of the interaction is available here: http://recordit.co/hEFY6g3sdT

## Background

This is leveraging the "dependent" field of "User Name" to provide a hint in an "orange-ish" tone with the background of the input box also be adjusted. This avoids having to use a subscription or interop with JavaScript for "set focus" behavior. 

The helper function sets inline styles to ensure that the appearance change is _forced_ regardless of included style sheets.

A more subtle approach might be to add a red `*` to Password when it is empty but when `User Name` has a value. 

This is a bit crude, so if there are refinements that are desired - please include them in the comments.