### PR TITLE
Problem: import 'openrc' is not working with current openrc

### DIFF
--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -21,7 +21,7 @@ processOpenRc model openRc =
     let
         regexes =
             { authUrl = Regex.regex "export OS_AUTH_URL=\"?([^\"\n]*)\"?"
-            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=\"?([^\"\n]*)\"?"
+            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN(?:_NAME|_ID)=\"?([^\"\n]*)\"?"
             , projectName = Regex.regex "export OS_PROJECT_NAME=\"?([^\"\n]*)\"?"
             , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"?([^\"\n]*)\"?"
             , username = Regex.regex "export OS_USERNAME=\"?([^\"\n]*)\"?"

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -20,11 +20,11 @@ processOpenRc : Model -> String -> Creds
 processOpenRc model openRc =
     let
         regexes =
-            { authUrl = Regex.regex "export OS_AUTH_URL=\"?([^\"]*)\"?"
-            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=\"?([^\"]*)\"?"
-            , projectName = Regex.regex "export OS_PROJECT_NAME=\"?([^\"]*)\"?"
-            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"?([^\"]*)\"?"
-            , username = Regex.regex "export OS_USERNAME=\"?([^\"]*)\"?"
+            { authUrl = Regex.regex "export OS_AUTH_URL=\"?([^\"\n]*)\"?"
+            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=\"?([^\"\n]*)\"?"
+            , projectName = Regex.regex "export OS_PROJECT_NAME=\"?([^\"\n]*)\"?"
+            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"?([^\"\n]*)\"?"
+            , username = Regex.regex "export OS_USERNAME=\"?([^\"\n]*)\"?"
             , password = Regex.regex "export OS_PASSWORD=\"(.*)\""
             }
 

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -20,11 +20,11 @@ processOpenRc : Model -> String -> Creds
 processOpenRc model openRc =
     let
         regexes =
-            { authUrl = Regex.regex "export OS_AUTH_URL=\"(.*)\""
-            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=\"(.*)\""
-            , projectName = Regex.regex "export OS_PROJECT_NAME=\"(.*)\""
-            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"(.*)\""
-            , username = Regex.regex "export OS_USERNAME=\"(.*)\""
+            { authUrl = Regex.regex "export OS_AUTH_URL=\"?([^\"]*)\"?"
+            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=\"?([^\"]*)\"?"
+            , projectName = Regex.regex "export OS_PROJECT_NAME=\"?([^\"]*)\"?"
+            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"?([^\"]*)\"?"
+            , username = Regex.regex "export OS_USERNAME=\"?([^\"]*)\"?"
             , password = Regex.regex "export OS_PASSWORD=\"(.*)\""
             }
 


### PR DESCRIPTION
Summary: Capture variable values with or without "

This changes it so that an `export`'d environment variable for the `openrc` should be wrapped in double quotes, or not be, and it will still be regex "captured" and set as the value for login.

My test cases were somewhat contrived, I see now. To be explicitly clear, I have included a link to them in gist form: 

https://gist.github.com/lenards/ad95edd90775a53d9d5b26236a968428