### PR TITLE
Problem: no way to write quick unit tests

### DIFF
--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -20,11 +20,11 @@ processOpenRc : Creds -> String -> Creds
 processOpenRc existingCreds openRc =
     let
         regexes =
-            { authUrl = Regex.regex "export OS_AUTH_URL=\"?([^\"]*)\"?"
-            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=\"?([^\"]*)\"?"
-            , projectName = Regex.regex "export OS_PROJECT_NAME=\"?([^\"]*)\"?"
-            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"?([^\"]*)\"?"
-            , username = Regex.regex "export OS_USERNAME=\"?([^\"]*)\"?"
+            { authUrl = Regex.regex "export OS_AUTH_URL=\"?([^\"\n]*)\"?"
+            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN(?:_NAME|_ID)=\"?([^\"\n]*)\"?"
+            , projectName = Regex.regex "export OS_PROJECT_NAME=\"?([^\"\n]*)\"?"
+            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"?([^\"\n]*)\"?"
+            , username = Regex.regex "export OS_USERNAME=\"?([^\"\n]*)\"?"
             , password = Regex.regex "export OS_PASSWORD=\"(.*)\""
             }
 

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -20,11 +20,11 @@ processOpenRc : Model -> String -> Creds
 processOpenRc model openRc =
     let
         regexes =
-            { authUrl = Regex.regex "export OS_AUTH_URL=\"(.*)\""
-            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=\"(.*)\""
-            , projectName = Regex.regex "export OS_PROJECT_NAME=\"(.*)\""
-            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"(.*)\""
-            , username = Regex.regex "export OS_USERNAME=\"(.*)\""
+            { authUrl = Regex.regex "export OS_AUTH_URL=\"?([^\"]*)\"?"
+            , projectDomain = Regex.regex "export OS_PROJECT_DOMAIN_NAME=\"?([^\"]*)\"?"
+            , projectName = Regex.regex "export OS_PROJECT_NAME=\"?([^\"]*)\"?"
+            , userDomain = Regex.regex "export OS_USER_DOMAIN_NAME=\"?([^\"]*)\"?"
+            , username = Regex.regex "export OS_USERNAME=\"?([^\"]*)\"?"
             , password = Regex.regex "export OS_PASSWORD=\"(.*)\""
             }
 

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -16,8 +16,8 @@ processError model error =
         ( { model | messages = newMsgs }, Cmd.none )
 
 
-processOpenRc : Model -> String -> Creds
-processOpenRc model openRc =
+processOpenRc : Creds -> String -> Creds
+processOpenRc existingCreds openRc =
     let
         regexes =
             { authUrl = Regex.regex "export OS_AUTH_URL=\"?([^\"]*)\"?"
@@ -40,12 +40,12 @@ processOpenRc model openRc =
                 |> Maybe.withDefault oldField
     in
         Creds
-            (newField regexes.authUrl model.creds.authUrl)
-            (newField regexes.projectDomain model.creds.projectDomain)
-            (newField regexes.projectName model.creds.projectName)
-            (newField regexes.userDomain model.creds.userDomain)
-            (newField regexes.username model.creds.username)
-            (newField regexes.password model.creds.password)
+            (newField regexes.authUrl existingCreds.authUrl)
+            (newField regexes.projectDomain existingCreds.projectDomain)
+            (newField regexes.projectName existingCreds.projectName)
+            (newField regexes.userDomain existingCreds.userDomain)
+            (newField regexes.username existingCreds.username)
+            (newField regexes.password existingCreds.password)
 
 
 providerNameFromUrl : HelperTypes.Url -> ProviderName

--- a/src/State.elm
+++ b/src/State.elm
@@ -99,7 +99,7 @@ update msg model =
                             { creds | password = password }
 
                         OpenRc openRc ->
-                            Helpers.processOpenRc model openRc
+                            Helpers.processOpenRc creds openRc
 
                 newModel =
                     { model | creds = newCreds }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,79 @@
+# Exosphere Tests
+
+
+## Installation
+
+To run test, you'll need to install `elm-test`.
+
+If you are comfortable installing it globally, then use the following:
+
+```
+npm install -g elm-test
+```
+
+Or, you can configure it to installed within `node_modules` and define an NPM script with the _path_ including `elm-test` via `.bin`.
+
+The current Exosphere project leverages globally installed Elm tools (see "./package.json")
+
+## Getting Started
+You can use the elm-test README as a way to orient to structure of tests:
+
+https://github.com/elm-community/elm-test#quick-start
+
+## Example, a single test
+
+Exploring one example might be helpful in pointing out some of the intending structure.
+
+```elm
+-- simple test suites need to import the following:
+import Expect exposing (Expectation)
+import Test exposing (..)
+
+testPalindrome : Test
+testPalindrome =
+    test "has no effect on a palindrome" <|
+        \() ->
+            let
+                palindrome =
+                    "hannah"
+            in
+                Expect.equal palindrome (String.reverse palindrome)
+```
+
+The `String` passing to `test` function is used to provide "output" for when there is a failure. It is common to use of the left pipeline operator, `<|`, as it avoids having to wrap the anonymous function in parentheses. The use of `()` (aka "Unit") is meant to flag, or "signal" (a person _waving_ to you), that nothing will be done with this argument.
+
+If you explore other projects for examples of tests, you will see that some use "the hockey stick", \_, for the anonymous function. There are individuals that argue this is supposed to be "less clear" since you're accepting an argument, and that argument for a `Test` will be disregarded or ignored.
+
+## Example, structuring tests using `describe`
+
+You can group together tests and example their functions using `describe`.
+
+```elm
+testPalindromes : Test
+testPalindromes =
+    describe "the overall test suite"
+        [ describe "simple palindrome cases without spaces"
+            [ test "has no effect on a palindrome" <|
+                \() ->
+                    let
+                        palindrome =
+                            "hannah"
+                    in
+                        Expect.equal palindrome (String.reverse palindrome)
+            ]
+        , describe "palindromed cases where spaces must be never"
+            [ test "has no effect on a palindrome" <|
+                \() ->
+                    let
+                        normalize s =
+                            String.split " " s |> String.join ""
+
+                        palindrome =
+                            "was it a rat i saw"
+                    in
+                        palindrome
+                            |> normalize
+                            |> Expect.equal (String.reverse (normalize palindrome))
+            ]
+        ]
+```

--- a/tests/TestData.elm
+++ b/tests/TestData.elm
@@ -1,0 +1,85 @@
+module TestData exposing (..)
+
+
+openrcV3withComments : String
+openrcV3withComments =
+    """
+#!/usr/bin/env bash
+# To use an OpenStack cloud you need to authenticate against the Identity
+# service named keystone, which returns a **Token** and **Service Catalog**.
+# The catalog contains the endpoints for all services the user/tenant has
+# access to - such as Compute, Image Service, Identity, Object Storage, Block
+# Storage, and Networking (code-named nova, glance, keystone, swift,
+# cinder, and neutron).
+#
+# *NOTE*: Using the 3 *Identity API* does not necessarily mean any other
+# OpenStack API is version 3. For example, your cloud provider may implement
+# Image API v1.1, Block Storage API v2, and Compute API v2.0. OS_AUTH_URL is
+# only for the Identity API served through keystone.
+export OS_AUTH_URL=https://cell.alliance.rebel:5000/v3
+# With the addition of Keystone we have standardized on the term **project**
+# as the entity that owns the resources.
+export OS_PROJECT_ID=1d00d4b1de1d00d4b1de1d00d4b1de
+export OS_PROJECT_NAME="cloud-riders"
+export OS_USER_DOMAIN_NAME="Default"
+if [ -z "$OS_USER_DOMAIN_NAME" ]; then unset OS_USER_DOMAIN_NAME; fi
+export OS_PROJECT_DOMAIN_ID="default"
+if [ -z "$OS_PROJECT_DOMAIN_ID" ]; then unset OS_PROJECT_DOMAIN_ID; fi
+# unset v2.0 items in case set
+unset OS_TENANT_ID
+unset OS_TENANT_NAME
+# In addition to the owning entity (tenant), OpenStack stores the entity
+# performing the action as the **user**.
+export OS_USERNAME="enfysnest"
+# With Keystone you pass the keystone password.
+echo "Please enter your OpenStack Password for project $OS_PROJECT_NAME as user $OS_USERNAME: "
+read -sr OS_PASSWORD_INPUT
+export OS_PASSWORD=$OS_PASSWORD_INPUT
+# If your configuration has multiple regions, we set that information here.
+# OS_REGION_NAME is optional and only valid in certain environments.
+export OS_REGION_NAME="CellOne"
+# Don't leave a blank variable, unset it if it was empty
+if [ -z "$OS_REGION_NAME" ]; then unset OS_REGION_NAME; fi
+export OS_INTERFACE=public
+export OS_IDENTITY_API_VERSION=3
+"""
+
+
+openrcV3 : String
+openrcV3 =
+    """
+#!/usr/bin/env bash
+
+export OS_AUTH_URL=https://cell.alliance.rebel:5000/v3
+export OS_PROJECT_ID=1d00d4b1de1d00d4b1de1d00d4b1de
+export OS_PROJECT_NAME="cloud-riders"
+export OS_USER_DOMAIN_NAME="Default"
+if [ -z "$OS_USER_DOMAIN_NAME" ]; then unset OS_USER_DOMAIN_NAME; fi
+export OS_PROJECT_DOMAIN_ID="default"
+if [ -z "$OS_PROJECT_DOMAIN_ID" ]; then unset OS_PROJECT_DOMAIN_ID; fi
+unset OS_TENANT_ID
+unset OS_TENANT_NAME
+export OS_USERNAME="enfysnest"
+echo "Please enter your OpenStack Password for project $OS_PROJECT_NAME as user $OS_USERNAME: "
+read -sr OS_PASSWORD_INPUT
+export OS_PASSWORD=$OS_PASSWORD_INPUT
+export OS_REGION_NAME="CellOne"
+if [ -z "$OS_REGION_NAME" ]; then unset OS_REGION_NAME; fi
+export OS_INTERFACE=public
+export OS_IDENTITY_API_VERSION=3
+"""
+
+
+openrcPreV3 : String
+openrcPreV3 =
+    """
+export OS_PROJECT_NAME="cloud-riders"
+export OS_USERNAME="enfysnest"
+export OS_IDENTITY_API_VERSION=3
+export OS_USER_DOMAIN_NAME="default"
+export OS_TENANT_NAME="enfysnest"
+export OS_AUTH_URL="https://cell.alliance.rebel:35357/v3"
+export OS_PROJECT_DOMAIN_NAME="default"
+export OS_REGION_NAME="CellOne"
+export OS_PASSWORD=$OS_PASSWORD_INPUT
+    """

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -50,6 +50,24 @@ processOpenRcSuite =
                     |> Helpers.processOpenRc emptyCreds
                     |> .authUrl
                     |> Expect.equal "https://cell.alliance.rebel:5000/v3"
+        , test "that project domain name is still matched" <|
+            \() ->
+                """
+                # newer OpenStack release seem to use _ID suffix
+                export OS_PROJECT_DOMAIN_NAME="super-specific"
+                """
+                    |> Helpers.processOpenRc emptyCreds
+                    |> .projectDomain
+                    |> Expect.equal "super-specific"
+        , test "that project domain ID is still matched" <|
+            \() ->
+                """
+                # newer OpenStack release seem to use _ID suffix
+                export OS_PROJECT_DOMAIN_ID="DEFAULT"
+                """
+                    |> Helpers.processOpenRc emptyCreds
+                    |> .projectDomain
+                    |> Expect.equal "DEFAULT"
         , test "ensure pre-'API Version 3' can be processed " <|
             \() ->
                 TestData.openrcPreV3

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,105 @@
+module Tests exposing (..)
+
+-- Test related Modules
+
+import Expect exposing (Expectation)
+import Test exposing (..)
+import TestData
+
+
+-- Exosphere Modules Under Test
+
+import Helpers
+import Types.Types exposing (Creds)
+
+
+emptyCreds : Creds
+emptyCreds =
+    Creds "" "" "" "" "" ""
+
+
+processOpenRcSuite : Test
+processOpenRcSuite =
+    describe "end result of processing imported openrc files"
+        [ test "ensure an empty file is unmatched" <|
+            \() ->
+                ""
+                    |> Helpers.processOpenRc emptyCreds
+                    |> Expect.equal (emptyCreds)
+        , test "that $OS_PASSWORD_INPUT is *not* processed" <|
+            \() ->
+                """
+                export OS_PASSWORD=$OS_PASSWORD_INPUT
+                """
+                    |> Helpers.processOpenRc emptyCreds
+                    |> .password
+                    |> Expect.equal ""
+        , test "that double quotes are not included in a processed match" <|
+            \() ->
+                """
+                export OS_AUTH_URL="https://cell.alliance.rebel:5000/v3"
+                """
+                    |> Helpers.processOpenRc emptyCreds
+                    |> .authUrl
+                    |> Expect.equal "https://cell.alliance.rebel:5000/v3"
+        , test "that double quotes are optional" <|
+            \() ->
+                """
+                export OS_AUTH_URL=https://cell.alliance.rebel:5000/v3
+                """
+                    |> Helpers.processOpenRc emptyCreds
+                    |> .authUrl
+                    |> Expect.equal "https://cell.alliance.rebel:5000/v3"
+        , test "ensure pre-'API Version 3' can be processed " <|
+            \() ->
+                TestData.openrcPreV3
+                    |> Helpers.processOpenRc emptyCreds
+                    |> Expect.equal
+                        (Creds
+                            "https://cell.alliance.rebel:35357/v3"
+                            "default"
+                            "cloud-riders"
+                            "default"
+                            "enfysnest"
+                            ""
+                        )
+        , test "ensure an 'API Version 3' open with comments works" <|
+            \() ->
+                TestData.openrcV3withComments
+                    |> Helpers.processOpenRc emptyCreds
+                    |> Expect.equal
+                        (Creds
+                            "https://cell.alliance.rebel:5000/v3"
+                            "default"
+                            "cloud-riders"
+                            "Default"
+                            "enfysnest"
+                            ""
+                        )
+        , test "ensure an 'API Version 3' open _without_ comments works" <|
+            \() ->
+                TestData.openrcV3
+                    |> Helpers.processOpenRc emptyCreds
+                    |> Expect.equal
+                        (Creds
+                            "https://cell.alliance.rebel:5000/v3"
+                            "default"
+                            "cloud-riders"
+                            "Default"
+                            "enfysnest"
+                            ""
+                        )
+        ]
+
+
+
+{-
+   type alias Creds =
+       { authUrl : String
+       , projectDomain : String
+       , projectName : String
+       , userDomain : String
+       , username : String
+       , password : String
+       }
+-}

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -108,16 +108,3 @@ processOpenRcSuite =
                             ""
                         )
         ]
-
-
-
-{-
-   type alias Creds =
-       { authUrl : String
-       , projectDomain : String
-       , projectName : String
-       , userDomain : String
-       , username : String
-       , password : String
-       }
--}

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.0.0",
+    "summary": "Test Suites for Exosphere, ",
+    "repository": "https://github.com/exosphere-project/exosphere.git",
+    "license": "BSD3",
+    "source-directories": [
+        "../src",
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "avh4/elm-beautiful-example": "1.1.1 <= v < 2.0.0",
+        "basti1302/elm-human-readable-filesize": "1.1.0 <= v < 2.0.0",
+        "eeue56/elm-html-test": "5.2.0 <= v < 6.0.0",
+        "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
+        "elm-community/maybe-extra": "4.0.0 <= v < 5.0.0",
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "truqu/elm-base64": "2.0.2 <= v < 3.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
The issues with #85 were much easier to understand with a simple test suite to look at variations of "openrc" data. 

This work introducing `elm-test` and defines a test suite for `Helpers.processOpenRc`. It includes a "narrow accepted arguments" change for `Helpers.processOpenRc` that makes the tests much easier to write. 
