### PR TITLE
Get all images from Glance API rather than first 25

### DIFF
--- a/src/Rest.elm
+++ b/src/Rest.elm
@@ -80,7 +80,7 @@ requestImages provider =
             Http.request
                 { method = "GET"
                 , headers = [ Http.header "X-Auth-Token" provider.authToken ]
-                , url = provider.endpoints.glance ++ "/v2/images"
+                , url = provider.endpoints.glance ++ "/v2/images?limit=999999"
                 , body = Http.emptyBody
                 , expect = Http.expectJson decodeImages
                 , timeout = Nothing


### PR DESCRIPTION
Fixes #46.

@julianpistorius and I decided to fetch the entire list of images from Glance rather than using the API's pagination, because we want to support fuzzy/partial text search. Glance doesn't support this so we need to do it client-side, which requires the whole list of images.

Problems to fix:
- `requestImages` is a fairly heavy API call (3 seconds and possibly hundreds/thousands of results) so we should keep track of when we last received a list of images, and only re-request if our cache is stale (rather than every time a user navigates to certain views).